### PR TITLE
Enhance header UI with more subdued color scheme

### DIFF
--- a/Client/components/Layout/Layout.tsx
+++ b/Client/components/Layout/Layout.tsx
@@ -2,13 +2,18 @@ import Head from "next/head";
 import React from "react";
 import { IParentComponentProps } from "@stego/interfaces/IParentComponentProps";
 import { createTheme, ThemeProvider } from "@mui/material";
-import { blue, pink } from "@mui/material/colors";
+import { pink } from "@mui/material/colors";
 import { Header } from "@stego/components/Header";
 import styles from "./Layout.module.css";
 
 const theme = createTheme({
     palette: {
-        primary: blue,
+        primary: {
+            main: "#1e3a5f",
+            light: "#2c5282",
+            dark: "#152844",
+            contrastText: "#ffffff"
+        },
         secondary: pink
     },
     spacing: 10


### PR DESCRIPTION
## Summary

Changed the header color from the bright Material-UI default blue to a custom slate/dark blue palette that's more professional and easier on the eyes.

## Changes

- Modified `Client/components/Layout/Layout.tsx` to use a custom primary color palette
- Main color: #1e3a5f (sophisticated dark blue)
- Light variant: #2c5282 (for hover states)
- Dark variant: #152844 (for active states)
- Contrast text: white for excellent readability

Closes #5

Generated with [Claude Code](https://claude.ai/code)